### PR TITLE
Add check for HAVE_STRUCT_STAT_ST_BLKSIZE and HAVE_STRUCT_STAT_ST_RDEV

### DIFF
--- a/rar_stream.c
+++ b/rar_stream.c
@@ -293,7 +293,7 @@ static int _rar_stat_from_header(struct RARHeaderDataEx *header,
 	 * SUBHEAD_TYPE_UOWNER), but it is not exposed in unRAR */
 	ssb->sb.st_uid = 0;
 	ssb->sb.st_gid = 0;
-#ifdef HAVE_ST_RDEV
+#if defined(HAVE_ST_RDEV) || defined(HAVE_STRUCT_STAT_ST_RDEV)
 	ssb->sb.st_rdev = 0;
 #endif
 	/* never mind signedness, we'll never get sizes big enough for that to
@@ -324,7 +324,7 @@ static int _rar_stat_from_header(struct RARHeaderDataEx *header,
 			&ssb->sb.st_mtime);
 	}
 
-#ifdef HAVE_ST_BLKSIZE
+#if defined(HAVE_ST_BLKSIZE) || defined(HAVE_STRUCT_STAT_ST_BLKSIZE)
 	ssb->sb.st_blksize = 0;
 #endif
 #ifdef HAVE_ST_BLOCKS


### PR DESCRIPTION
Hello,

Since PHP 7.3 the Autoconf macros `AC_STRUCT_ST_BLKSIZE` and `AC_STRUCT_ST_RDEV` were replaced with the new `AC_CHECK_MEMBERS`.

Previous macros defined constants `HAVE_ST_BLKIZE` and `HAVE_ST_RDEV`. New macros used in PHP build system now define the `HAVE_STAT_ST_BLKSIZE` and `HAVE_STAT_ST_RDEV` in the system `php_config.h` file.

This patch provides also compatibility with PHP <= 7.2 versions.

Refs:
- https://github.com/php/php-src/commit/d2184efb7be1b3bfb355e4a6e671ceacc3896eeb

Thanks.