### PR TITLE
Fix incorrect buffer_size calculation with streams.

### DIFF
--- a/rar_stream.c
+++ b/rar_stream.c
@@ -509,9 +509,8 @@ php_stream *php_stream_rar_open(char *arc_name,
 	else {
 		/* no need to allocate a buffer bigger than the file uncomp size */
 		size_t buffer_size = (size_t)
-			MIN((uint64) RAR_CHUNK_BUFFER_SIZE,
-			INT32TO64(self->header_data.UnpSizeHigh,
-			self->header_data.UnpSize));
+			INT32TO64(self->header_data.UnpSizeHigh, self->header_data.UnpSize);
+
 		int process_result = RARProcessFileChunkInit(self->rar_handle);
 
 		if (_rar_handle_error(process_result TSRMLS_CC) == FAILURE) {

--- a/rar_stream.c
+++ b/rar_stream.c
@@ -909,9 +909,7 @@ static php_stream *php_stream_rar_opener(php_stream_wrapper *wrapper,
 	{
 		/* no need to allocate a buffer bigger than the file uncomp size */
 		size_t buffer_size = (size_t)
-			MIN((uint64) RAR_CHUNK_BUFFER_SIZE,
-			INT32TO64(self->header_data.UnpSizeHigh,
-			self->header_data.UnpSize));
+			INT32TO64(self->header_data.UnpSizeHigh, self->header_data.UnpSize);
 		rar_result = RARProcessFileChunkInit(self->rar_handle);
 
 		if ((rar_error = _rar_error_to_string(rar_result)) != NULL) {


### PR DESCRIPTION
This contains a patch submitted months ago on the PHP bug tracker but it appears that it is abandoned?  
Anyways, here is the mentioned bug: https://bugs.php.net/bug.php?id=76592

If the unpacked size was bigger than RAR_CHUNK_BUFFER_SIZE,
then buffer_size would always be RAR_CHUNK_BUFFER_SIZE.

Signed-off-by: pierobot <pierobot@users.noreply.github.com>