### PR TITLE
Explicitly specify obj_dir

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -31,7 +31,7 @@ if (PHP_RAR != "no") {
 		arcread.cpp filefn.cpp \
 		global.cpp list.cpp \
 		encname.cpp file.cpp \
-		secpassword.cpp options.cpp", "rar");
+		secpassword.cpp options.cpp", "rar", "rarobj");
 
 	AC_DEFINE("HAVE_RAR", 1, "Rar support");
 }


### PR DESCRIPTION
Without that, phpize builds fail because there is rar.c and rar.cpp,
and both are compiled to rar.obj in the same folder.  This appears to
be an upstream bug[1], but even if so, that won't be fixed for PHP 7
anymore, so we work around.

[1] <https://github.com/php/php-src/blob/php-8.1.0/win32/build/confutils.js#L1617-L1625>