### PR TITLE
Issue php82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /modules
 /missing
 /.deps
+*.dep
 /.libs
 /Makefile
 /Makefile.fragments
@@ -36,6 +37,7 @@
 /libtool
 /mkinstalldirs
 /ltmain.sh
+/ltmain.sh.backup
 /.cproject
 /.project
 /.settings

--- a/rararch.c
+++ b/rararch.c
@@ -970,6 +970,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rararchive_void, 0)
 ZEND_END_ARG_INFO()
+
+#if PHP_VERSION_ID >= 80200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rararchive_tostring, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#else
+#define arginfo_rararchive_tostring arginfo_rararchive_void
+#endif
 /* }}} */
 
 static zend_function_entry php_rararch_class_functions[] = {
@@ -984,7 +991,7 @@ static zend_function_entry php_rararch_class_functions[] = {
 	PHP_ME_MAPPING(isBroken,		rar_broken_is,			arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setAllowBroken,	rar_allow_broken_set,	arginfo_rararchive_setallowbroken, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(close,			rar_close,				arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
-	PHP_ME(rararch,					__toString,				arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
+	PHP_ME(rararch,					__toString,				arginfo_rararchive_tostring,	ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(__construct,		rar_bogus_ctor,			arginfo_rararchive_void,		ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
 #if PHP_MAJOR_VERSION >= 8
 	PHP_ME(rararch,					getIterator,			arginfo_rararchive_getiterator,	ZEND_ACC_PUBLIC)

--- a/rarentry.c
+++ b/rarentry.c
@@ -735,6 +735,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rar_void, 0)
 ZEND_END_ARG_INFO()
+
+#if PHP_VERSION_ID >= 80200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rar_tostring, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#else
+#define arginfo_rar_tostring arginfo_rar_void
+#endif
 /* }}} */
 
 static zend_function_entry php_rar_class_functions[] = {
@@ -755,7 +762,7 @@ static zend_function_entry php_rar_class_functions[] = {
 	PHP_ME(rarentry,		getRedirType,		arginfo_rar_void,	ZEND_ACC_PUBLIC)
 	PHP_ME(rarentry,		isRedirectToDirectory,	arginfo_rar_void,	ZEND_ACC_PUBLIC)
 	PHP_ME(rarentry,		getRedirTarget,	arginfo_rar_void,	ZEND_ACC_PUBLIC)
-	PHP_ME(rarentry,		__toString,			arginfo_rar_void,	ZEND_ACC_PUBLIC)
+	PHP_ME(rarentry,		__toString,			arginfo_rar_tostring,	ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(__construct,	rar_bogus_ctor,	arginfo_rar_void,	ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
 	{NULL, NULL, NULL}
 };


### PR DESCRIPTION
Without, test suite fails with
```
TEST 2/115 [tests/002.phpt]
========DIFF========
001+ Warning: RarArchive::__toString() implemented without string return type in Unknown on line 0
002+ 
003+ Warning: RarEntry::__toString() implemented without string return type in Unknown on line 0
     array(2) {
       [0]=>
       object(RarEntry)#%d (%d) {
--
========DONE========
FAIL rar_list() function [tests/002.phpt] 

```

With this fix
```
=====================================================================
PHP         : /opt/remi/php82/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/rar/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php82/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/rar/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/rar
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-09-15 08:26:08
=====================================================================
PASS rar_open() function [tests/001.phpt] 
PASS rar_list() function [tests/002.phpt] 
PASS rar_entry_get() function [tests/003.phpt] 
PASS RarEntry::extract() method [tests/004.phpt] 
PASS rar_comment_get() function [tests/005.phpt] 
PASS RarEntry::getCrc() method in multi-volume archives (PECL bug #9470) [tests/006.phpt] 
PASS rar_open() function with a non-RAR [tests/007.phpt] 
PASS rar_entry_get() function [tests/008.phpt] 
PASS RarEntry::getName() function with unicode filenames [tests/009.phpt] 
PASS RarEntry::getStream() function (good RAR file, one volume) [tests/010.phpt] 
PASS RarEntry::getStream() function (good RAR file, several volumes) [tests/011.phpt] 
PASS RarEntry::getStream() function (bad RAR file) [tests/012.phpt] 
PASS rar_entry_get() and RarEntry::getName() coherence [tests/013.phpt] 
PASS RarEntry::getStream() on unicode entry [tests/014.phpt] 
PASS rar_close() liberates resource (PECL bug #9649) [tests/015.phpt] 
PASS RarEntry::extract() method (corrupt RAR file) [tests/016.phpt] 
PASS RarEntry::extract() with unicode files [tests/017.phpt] 
PASS rar_list()/rar_entry_get() with not first volume [tests/018.phpt] 
PASS RarEntry::getStream() function (store method) [tests/019.phpt] 
PASS RarEntry::getStream() function (solid archive) [tests/020.phpt] 
PASS RarEntry::isDirectory() basic test [tests/021.phpt] 
PASS RarEntry::extract() with directory [tests/022.phpt] 
PASS RarEntry::getStream() with directory [tests/023.phpt] 
PASS rar_open()/RarEntry::getStream() (headers level password) [tests/024.phpt] 
PASS rar_open()/RarEntry::extract() (headers level password) [tests/025.phpt] 
PASS RarEntry::getStream() (file level password) [tests/026.phpt] 
PASS RarEntry::getStream() with Linux directories and links [tests/027.phpt] 
PASS RarArchive::open() basic test [tests/028.phpt] 
PASS RarArchive::getEntries() basic test [tests/029.phpt] 
PASS RarArchive::getEntry() basic test [tests/030.phpt] 
PASS RarArchive::getComment() basic test [tests/031.phpt] 
PASS RarArchive traversal with multi-part archive [tests/032.phpt] 
PASS rar_solid_is() basic test [tests/033.phpt] 
PASS RarException::(set/is)UsingExceptions() test [tests/034.phpt] 
PASS rar_entry_get() non-existent file with exceptions [tests/035.phpt] 
PASS rar_open() non-existent archive with exceptions [tests/036.phpt] 
PASS RarEntry::getStream(), password not given, with exceptions [tests/037.phpt] 
PASS RarArchive get iterator on closed file [tests/038.phpt] 
PASS Access RAR archive with missing volumes [tests/039.phpt] 
SKIP RarEntry::getUnpackedSize() on platforms with 32-bit longs [tests/040.phpt] reason: this test is for 32bit platforms only
PASS RarEntry::getUnpackedSize() on platforms with 64-bit longs [tests/041.phpt] 
PASS rar_open() with volume find callback basic test [tests/042.phpt] 
PASS rar_open() with volume find (callback variants 1) [tests/043.phpt] 
PASS rar_open() with volume find (callback variants 2) [tests/044.phpt] 
PASS rar_open() with invalid volume callback [tests/045.phpt] 
PASS RarEntry::getStream() function (broken set fixed with volume callback) [tests/046.phpt] 
PASS RarEntry::extract() function (broken set fixed with volume callback) [tests/047.phpt] 
SKIP RarArchive::open() volume callback long return (case MAXPATHLEN <= NM) [tests/048.phpt] reason: ; this test is for systems where MAXPATHLEN <= 1024
PASS RarArchive::open() volume callback long return (case MAXPATHLEN > NM) [tests/049.phpt] 
PASS Stream wrapper basic test [tests/050.phpt] 
PASS Stream wrapper relative path test [tests/051.phpt] 
PASS Stream wrapper archive/file not found [tests/052.phpt] 
PASS Stream wrapper malformed url [tests/053.phpt] 
PASS Stream wrapper with header or file level passwords [tests/054.phpt] 
PASS Stream wrapper with volume find callback [tests/055.phpt] 
PASS RAR file stream stat [tests/056.phpt] 
PASS RAR file stream stat consistency with url stat [tests/057.phpt] 
PASS RAR file stream stat applied to directory consistency with url stat [tests/058.phpt] 
PASS url stat test [tests/059.phpt] 
PASS RAR directory stream basic test [tests/060.phpt] 
PASS RAR directory stream attempt on file [tests/061.phpt] 
PASS RAR directory stream stat [tests/062.phpt] 
PASS RAR directory stream stat consistency with url stat [tests/063.phpt] 
PASS RAR directory-aware traversal with directory streams [tests/064.phpt] 
PASS Directory streams compatibility with RecursiveDirectoryIterator [tests/065.phpt] 
PASS RarEntry::extract() (file level password) [tests/066.phpt] 
SKIP RarEntry::extract() process extended (Windows) [tests/067.phpt] reason: test is not working under run-tests
SKIP RarArchive direct instantiation does not crash (PHP 5.x) [tests/068.phpt] reason: for PHP 5.x
SKIP RarEntry direct instantiation does not crash (PHP 5.x) [tests/069.phpt] reason: for PHP 5.x
PASS URL stat PHP_STREAM_URL_STAT_QUIET does not leak memory [tests/070.phpt] 
PASS RarEntry::getPosition() test [tests/071.phpt] 
PASS rar_list handles files with non-unique entry names [tests/072.phpt] 
PASS RarEntry::getStream handles files with non-unique entry names [tests/073.phpt] 
PASS RarEntry::extract handles files with non-unique entry names [tests/074.phpt] 
PASS RarEntry::getStream NULL can be given to indicate there's no password [tests/075.phpt] 
PASS RarEntry::extract NULL can be given to indicate there's no password [tests/076.phpt] 
PASS RarArchive::open NULL can be given to indicate there's no password [tests/077.phpt] 
PASS Traversal of volume with only an archive continue from last volume [tests/078.phpt] 
PASS RarArchive count elements handler test [tests/079.phpt] 
PASS File stream EOF behavior [tests/080.phpt] 
PASS rar_list et al. give consistent results if called twice [tests/081.phpt] 
PASS RarArchive read_property handler basic test [tests/082.phpt] 
PASS RarArchive read_property handler non-int valid dimensions [tests/083.phpt] 
PASS RarArchive read_property handler invalid dimensions [tests/084.phpt] 
PASS RarArchive has_property handler is given a closed archive [tests/085.phpt] 
PASS RarArchive write_property gives a fatal error [tests/086.phpt] 
PASS RarArchive read_property gives a fatal error on a write context [tests/087.phpt] 
PASS RarArchive write_property gives a fatal error [tests/088.phpt] 
PASS RarArchive unset_property gives a fatal error [tests/089.phpt] 
PASS RarArchive has_property gives a fatal error [tests/090.phpt] 
PASS RarArchive::isBroken/rar_broken_is test [tests/091.phpt] 
PASS RarArchive::setAllowBroken has the desired effect [tests/092.phpt] 
PASS Traversal of RarArchive with foreach by reference gives error [tests/093.phpt] 
PASS rar_close is called twice [tests/094.phpt] 
PASS Wrapper cache exaustion test [tests/095.phpt] 
PASS Module info test [tests/096.phpt] 
PASS PECL bug #18449 (Extraction of uncompressed and encrypted files fails) [tests/097.phpt] 
PASS PECL bug #18449 (Extraction of uncompressed and encrypted files fails; stream variant) [tests/098.phpt] 
PASS Bug #59939: Streaming empty file from archive issues a warning [tests/099.phpt] 
PASS fopen modes 'r' and 'rb' are the only allowed [tests/100.phpt] 
PASS Supports version 5 RAR files [tests/101.phpt] 
PASS RarArchive direct instantiation does not crash (PHP 7) [tests/102.phpt] 
PASS RarEntry direct instantiation does not crash (PHP 7) [tests/103.phpt] 
PASS Clone of RarArchive is forbidden (PHP 7) [tests/104.phpt] 
SKIP Clone of RarArchive is forbidden (PHP 5.x) [tests/105.phpt] reason: for PHP 5.x
PASS Stat times don't depend on timezone (cf. 056.phpt) [tests/106.phpt] 
PASS Redirection functions [tests/107.phpt] 
PASS RarEntry::getPackedSize() [tests/108.phpt] 
PASS RarEntry::getHostOs() [tests/109.phpt] 
PASS RarEntry::getFileTime() [tests/110.phpt] 
PASS RarEntry::getVersion() [tests/111.phpt] 
PASS RarEntry::getMethod() [tests/112.phpt] 
PASS RarEntry::isEncrypted() [tests/113.phpt] 
PASS Bug 76592: solid files are partially extracted [tests/114.phpt] 
PASS getIterator() (PHP 8+) [tests/115.phpt] 
=====================================================================
TIME END 2022-09-15 08:26:10

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :  115               109
Tests skipped   :    6 (  5.2%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :  109 ( 94.8%) (100.0%)
---------------------------------------------------------------------
Time taken      :    2 seconds
=====================================================================

```