### PR TITLE
Fixed __toString method warnings in RarArchive and RarEntry classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /modules
 /missing
 /.deps
+*.dep
 /.libs
 /Makefile
 /Makefile.fragments
@@ -36,6 +37,7 @@
 /libtool
 /mkinstalldirs
 /ltmain.sh
+/ltmain.sh.backup
 /.cproject
 /.project
 /.settings

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,3 +83,67 @@ jobs:
       phpVersion: '8.0'
       clang: true
       valgrind: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_1
+      displayName: PHP 8.1 ZTS
+      phpVersion: '8.1'
+      zts: true
+      publishCoverage: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_1_valgrind
+      displayName: PHP 8.1 (valgrind, clang)
+      phpVersion: '8.1'
+      clang: true
+      valgrind: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_2
+      displayName: PHP 8.2 ZTS
+      phpVersion: '8.2'
+      zts: true
+      publishCoverage: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_2_valgrind
+      displayName: PHP 8.2 (valgrind, clang)
+      phpVersion: '8.0'
+      clang: true
+      valgrind: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_3
+      displayName: PHP 8.3 ZTS
+      phpVersion: '8.3'
+      zts: true
+      publishCoverage: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_3_valgrind
+      displayName: PHP 8.3 (valgrind, clang)
+      phpVersion: '8.3'
+      clang: true
+      valgrind: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_4
+      displayName: PHP 8.4 ZTS
+      phpVersion: '8.4'
+      zts: true
+      publishCoverage: true
+
+  - template: azure-template.yml
+    parameters:
+      name: php_8_4_valgrind
+      displayName: PHP 8.4 (valgrind, clang)
+      phpVersion: '8.4'
+      clang: true
+      valgrind: true

--- a/rararch.c
+++ b/rararch.c
@@ -970,6 +970,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rararchive_void, 0)
 ZEND_END_ARG_INFO()
+
+#if PHP_VERSION_ID >= 80200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rararchive_tostring, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#else
+#define arginfo_rararchive_tostring arginfo_rararchive_void
+#endif
 /* }}} */
 
 static zend_function_entry php_rararch_class_functions[] = {
@@ -984,7 +991,7 @@ static zend_function_entry php_rararch_class_functions[] = {
 	PHP_ME_MAPPING(isBroken,		rar_broken_is,			arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setAllowBroken,	rar_allow_broken_set,	arginfo_rararchive_setallowbroken, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(close,			rar_close,				arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
-	PHP_ME(rararch,					__toString,				arginfo_rararchive_void,		ZEND_ACC_PUBLIC)
+	PHP_ME(rararch,					__toString,				arginfo_rararchive_tostring,	ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(__construct,		rar_bogus_ctor,			arginfo_rararchive_void,		ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
 #if PHP_MAJOR_VERSION >= 8
 	PHP_ME(rararch,					getIterator,			arginfo_rararchive_getiterator,	ZEND_ACC_PUBLIC)

--- a/rarentry.c
+++ b/rarentry.c
@@ -735,6 +735,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rar_void, 0)
 ZEND_END_ARG_INFO()
+
+#if PHP_VERSION_ID >= 80200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rar_tostring, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#else
+#define arginfo_rar_tostring arginfo_rar_void
+#endif
 /* }}} */
 
 static zend_function_entry php_rar_class_functions[] = {
@@ -755,7 +762,7 @@ static zend_function_entry php_rar_class_functions[] = {
 	PHP_ME(rarentry,		getRedirType,		arginfo_rar_void,	ZEND_ACC_PUBLIC)
 	PHP_ME(rarentry,		isRedirectToDirectory,	arginfo_rar_void,	ZEND_ACC_PUBLIC)
 	PHP_ME(rarentry,		getRedirTarget,	arginfo_rar_void,	ZEND_ACC_PUBLIC)
-	PHP_ME(rarentry,		__toString,			arginfo_rar_void,	ZEND_ACC_PUBLIC)
+	PHP_ME(rarentry,		__toString,			arginfo_rar_tostring,	ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(__construct,	rar_bogus_ctor,	arginfo_rar_void,	ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
 	{NULL, NULL, NULL}
 };

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -163,5 +163,5 @@ array(2) {
 
 Warning: rar_open(): Failed to open %s: ERAR_EOPEN (file open error) in %s on line %d
 
-Warning: rar_list() expects parameter 1 to be RarArchive, boo%s given in %s on line %d
+Warning: rar_list() expects parameter 1 to be RarArchive, %s given in %s on line %d
 Done

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -91,5 +91,5 @@ object(RarEntry)#%d (%d) {
 
 Warning: rar_open(): Failed to open %s: ERAR_EOPEN (file open error) in %s on line %d
 
-Warning: rar_entry_get() expects parameter 1 to be RarArchive, boo%s given in %s on line %d
+Warning: rar_entry_get() expects parameter 1 to be RarArchive, %s given in %s on line %d
 Done

--- a/tests/008.phpt
+++ b/tests/008.phpt
@@ -31,6 +31,6 @@ bool(false)
 
 Warning: rar_open(): Failed to open %s: ERAR_EOPEN (file open error) in %s on line %d
 
-Warning: rar_entry_get() expects parameter 1 to be RarArchive, boo%s given in %s on line %d
+Warning: rar_entry_get() expects parameter 1 to be RarArchive, %s given in %s on line %d
 
 Done


### PR DESCRIPTION
Since the official php-rar repo has been abandoned, I opened this PR to fix the obnoxious warnings that started popping up in modern PHP versions 8.2, 8.2 and now 8.4